### PR TITLE
Add UTF-8 encoding as default and allow encoding to be changed

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for perl distribution Mojo-Redis
 3.02 Not Released
  - Add Mojo::Redis::Cache->memomize_p()
  - Add examples/twitter.pl
+ - Add UTF-8 encoding as default and allow encoding to be changed #1
  - Add documentation for events #2
  - Add support for connecting to unix socket #12
  - Add support for refreshing cache #16

--- a/t/connection.t
+++ b/t/connection.t
@@ -59,6 +59,15 @@ isnt $db->connection, $conn, 'new connection when disconnected';
 
 is $redis->{connections}++, 7, 'connections emitted';
 
+# Encoding
+my $str = 'I ♥ Mojolicious!';
+$conn = $db->connection;
+is $conn->encoding, 'UTF-8', 'default encoding';
+$conn->write_p(qw(set t:redis:encoding), $str)->wait;
+$conn->write_p(qw(get t:redis:encoding))->then(sub { @res = @_ })->wait;
+$conn->write_p(qw(del t:redis:encoding))->wait;
+is_deeply \@res, [$str], 'unicode encoding';
+
 # Fork-safety
 $conn = $db->connection;
 undef $db;


### PR DESCRIPTION
See also:

* https://github.com/jhthorsen/mojo-redis/issues/1
* https://github.com/jhthorsen/mojo-redis2/blob/master/lib/Mojo/Redis2.pm#L22

I don't get why this code doesn't work. Any help is more than welcome!

This is the output from the test:

```
not ok 13 - unicode encoding
#   Failed test 'unicode encoding'
#   at t/connection.t line 69.
Wide character in print at Test2/Formatter/TAP.pm line 113.
#     Structures begin differing at:
#          $got->[0] = 'I ♥ Mojoliciou'
#     $expected->[0] = 'I ♥ Mojolicious!'
```