### PR TITLE
Response data shouldn't be passed to decode when null

### DIFF
--- a/lib/Mojo/Redis/Connection.pm
+++ b/lib/Mojo/Redis/Connection.pm
@@ -130,7 +130,7 @@ sub _parse_message_cb {
       if    ($type eq '-') { push @err, $data }
       elsif ($type eq ':') { push @res, 0 + $data }
       elsif ($type eq '*' and ref $data) { push @messages, @$data }
-      else                               { push @res,      $encoding ? Mojo::Util::decode($encoding, $data) : $data }
+      else { push @res, $encoding && defined $data ? Mojo::Util::decode($encoding, $data) : $data }
     }
 
     my $p = shift @{$self->{waiting} || []};

--- a/t/connection.t
+++ b/t/connection.t
@@ -66,6 +66,8 @@ $conn = $db->connection;
 
 is $redis->encoding, 'UTF-8', 'default redis encoding';
 is $conn->encoding,  'UTF-8', 'encoding passed on to connection';
+$conn->write_p(qw(get t:redis:encoding))->then(sub { @res = @_ })->wait;
+is_deeply \@res, [undef], 'undefined key not decoded';
 $conn->write_p(qw(set t:redis:encoding), $str)->wait;
 $conn->write_p(qw(get t:redis:encoding))->then(sub { @res = @_ })->wait;
 is_deeply \@res, [$str], 'unicode encoding';


### PR DESCRIPTION
perl -Ilib -MMojo::Redis -E'say defined Mojo::Redis->new->db->get("nonexistent_key")'

This currently returns 1 and the warning `Use of uninitialized value $bytes in string at /opt/perl-5.28.0/lib/site_perl/5.28.0/Mojo/Util.pm line 121.`. It should return false (result is undef).