### PR TITLE
Add destructor to Connection object

### DIFF
--- a/lib/Mojo/Redis/Connection.pm
+++ b/lib/Mojo/Redis/Connection.pm
@@ -14,6 +14,11 @@ has ioloop   => sub { Carp::confess('ioloop is required in constructor') };
 has protocol => sub { Carp::confess('protocol is required in constructor') };
 has url      => sub { Carp::confess('url is required in constructor') };
 
+sub DESTROY {
+  my $self = shift;
+  $self->disconnect if defined $self->{pid} and $self->{pid} == $$;
+}
+
 sub disconnect {
   my $self = shift;
   $self->{stream}->close if $self->{stream};
@@ -71,6 +76,7 @@ sub _connect {
       unshift @{$self->{write}}, [$self->_encode(SELECT => $url->path->[0])] if length $url->path->[0];
       unshift @{$self->{write}}, [$self->_encode(AUTH   => $url->password)]  if length $url->password;
       $self->{stream} = $stream;
+      $self->{pid} = $$;
       $self->emit('connect');
       $self->_write;
     }

--- a/lib/Mojo/Redis/Connection.pm
+++ b/lib/Mojo/Redis/Connection.pm
@@ -75,8 +75,8 @@ sub _connect {
 
       unshift @{$self->{write}}, [$self->_encode(SELECT => $url->path->[0])] if length $url->path->[0];
       unshift @{$self->{write}}, [$self->_encode(AUTH   => $url->password)]  if length $url->password;
+      $self->{pid}    = $$;
       $self->{stream} = $stream;
-      $self->{pid} = $$;
       $self->emit('connect');
       $self->_write;
     }
@@ -151,7 +151,8 @@ sub _on_close_cb {
     return unless $self;
     my ($stream, $err) = @_;
     delete $self->{$_} for qw(id stream);
-    $self->emit(error => $err) if $err;
+    $self->emit(error => $err) if @_ == 2;
+    $self->emit('close') if @_ == 1;
     warn qq([@{[$self->_id]}] @{[$err ? "ERROR $err" : "CLOSED"]}\n) if DEBUG;
   };
 }
@@ -250,6 +251,12 @@ from a Redis server.
 You probably want to use L<Mojo::Redis> instead of this class.
 
 =head1 EVENTS
+
+=head2 close
+
+  $cb = $self->on(close => sub { my ($self) = @_; });
+
+Emitted when the connection to the redis server gets closed.
 
 =head2 connect
 

--- a/t/connection.t
+++ b/t/connection.t
@@ -108,9 +108,10 @@ is @{$redis->{queue}}, 0, 'database was not enqued';
 
 # Connection closes when ref is lost
 $db = $redis->db;
-$db->get_p($0)->wait;    # Make sure we are connected
+$db->get_p($0)->wait;
+ok $db->connection->is_connected, 'connected';
 my $closed;
-$db->connection->{stream}->on(close => sub { $closed++ });
+$db->connection->on(close => sub { $closed++ });
 $redis->max_connections(0);
 undef $db;
 ok $closed, 'connection was closed on destruction';

--- a/t/connection.t
+++ b/t/connection.t
@@ -106,4 +106,13 @@ $redis->url->host($ENV{TEST_ONLINE} =~ /localhost/ ? '127.0.0.1' : 'localhost');
 $db = undef;
 is @{$redis->{queue}}, 0, 'database was not enqued';
 
+# Connection closes when ref is lost
+$db = $redis->db;
+$db->get_p($0)->wait;    # Make sure we are connected
+my $closed;
+$db->connection->{stream}->on(close => sub { $closed++ });
+$redis->max_connections(0);
+undef $db;
+ok $closed, 'connection was closed on destruction';
+
 done_testing;


### PR DESCRIPTION
The Connection object currently has no destructor so its stream remains open even if the object is no longer referenced. Add a destructor that closes the connection if the PID is still the same (to avoid issues where a forked process closes its parent's stream, a la AutoInactiveDestroy).