### PR TITLE
Blocking connection is not fork safe

### DIFF
--- a/t/connection.t
+++ b/t/connection.t
@@ -98,6 +98,11 @@ $redis->{pid} = -1;
 isnt $redis->db->connection, $conn, 'new fork gets a new connecion';
 undef $conn;
 $redis->{pid} = $$;
+$conn = $redis->_blocking_connection;
+$redis->{pid} = -1;
+isnt $redis->_blocking_connection, $conn, 'new fork gets a new blocking connection';
+undef $conn;
+$redis->{pid} = $$;
 
 note 'Connection closes when ref is lost';
 $db = $redis->db;


### PR DESCRIPTION
Mojo::Redis::Database uses `$redis->_blocking_connection` for blocking queries, but this connection is permanently stored in the `$redis` object and not fork safe. I added a failing test but I'm not sure what approach you want to take to fix it.