### PR TITLE
Bundle protocol parser #38

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,4 @@
 # You can install this projct with curl -L http://cpanmin.us | perl - https://github.com/jhthorsen/mojo-redis/archive/master.tar.gz
 requires "Mojolicious"     => "7.80";
-requires "Protocol::Redis" => "1.0006";
 
 test_requires "Test::More" => "0.88";

--- a/lib/Mojo/Redis.pm
+++ b/lib/Mojo/Redis.pm
@@ -16,7 +16,7 @@ has encoding        => 'UTF-8';
 has max_connections => 5;
 
 has protocol_class => do {
-  my $class = $ENV{MOJO_REDIS_PROTOCOL} || 'Protocol::Redis';
+  my $class = $ENV{MOJO_REDIS_PROTOCOL} || 'Mojo::Redis::Protocol';
   eval "require $class; 1" or die $@;
   $class;
 };
@@ -156,7 +156,7 @@ limitations:
 
 =item * Cannot handle binary data
 
-L<Mojo::Redis::Cache> uses L<Protocol::Redis> for now, since
+L<Mojo::Redis::Cache> uses L<Mojo::Redis::Protocol> for now, since
 L<Protocol::Redis::XS> fail to handle binary data.
 
 See L<https://github.com/dgl/protocol-redis-xs/issues/4> for more information.
@@ -172,9 +172,7 @@ See L<https://github.com/dgl/protocol-redis-xs/issues/5> for more information.
 =back
 
 If you experience any issues with L<Protocol::Redis::XS> then please report
-them to L<https://github.com/dgl/protocol-redis-xs/issues>. It is still the
-default L</protocol> though, since it is a lot faster than L<Protocol::Redis>
-for most tasks.
+them to L<https://github.com/dgl/protocol-redis-xs/issues>.
 
 =head1 EVENTS
 
@@ -209,10 +207,12 @@ Maximum number of idle database handles to cache for future use, defaults to
 =head2 protocol_class
 
   $str   = $redis->protocol_class;
+  $redis = $redis->protocol_class("Mojo::Redis::Protocol");
+  $redis = $redis->protocol_class("Protocol::Redis");
   $redis = $redis->protocol_class("Protocol::Redis::XS");
 
-Default to L<Protocol::Redis>. This will be changed in the future, if we see a
-more stable version of an alternative to L<Protocol::Redis::XS>.  See
+Default to L<Mojo::Redis::Protocol>. This will be changed in the future, if we
+see a more stable version of an alternative to L<Protocol::Redis::XS>.  See
 L</CAVEATS> for details.
 
 =head2 pubsub

--- a/lib/Mojo/Redis/Cache.pm
+++ b/lib/Mojo/Redis/Cache.pm
@@ -2,7 +2,7 @@ package Mojo::Redis::Cache;
 use Mojo::Base -base;
 
 use Mojo::JSON;
-use Protocol::Redis;
+use Mojo::Redis::Protocol;
 use Scalar::Util 'blessed';
 use Storable    ();
 use Time::HiRes ();
@@ -10,9 +10,7 @@ use Time::HiRes ();
 use constant OFFLINE => $ENV{MOJO_REDIS_CACHE_OFFLINE};
 
 has connection => sub {
-  OFFLINE
-    ? shift->_offline_connection
-    : shift->redis->_dequeue->protocol(Protocol::Redis->new(api => 1))->encoding(undef);
+  OFFLINE ? shift->_offline_connection : shift->redis->_dequeue->protocol(Mojo::Redis::Protocol->new)->encoding(undef);
 };
 has deserialize    => sub { \&Storable::thaw };
 has default_expire => 600;

--- a/lib/Mojo/Redis/Connection.pm
+++ b/lib/Mojo/Redis/Connection.pm
@@ -48,8 +48,7 @@ sub _encode {
   my $self     = shift;
   my $protocol = $self->protocol;
 
-  return $protocol->encoding($self->encoding)->encode({type => '*', data => [map { +{type => '$', data => $_} } @_]})
-    if $protocol->can('encoding');
+  return $protocol->encoding($self->encoding)->encode(\@_) if $protocol->can('encoding');
 
   my $encoding = $self->encoding;
   return $protocol->encode({

--- a/lib/Mojo/Redis/Protocol.pm
+++ b/lib/Mojo/Redis/Protocol.pm
@@ -1,0 +1,240 @@
+package Mojo::Redis::Protocol;
+use Mojo::Base -base;
+
+use Carp qw(confess croak);
+use Encode 'find_encoding';
+
+use constant DEBUG => $ENV{MOJO_REDIS_DEBUG} || 0;
+
+our %ENCODING;    # Internal usage
+
+has on_message => undef;
+
+sub encode {
+  my ($self, @stack) = @_;
+
+  my $str = '';
+  while (@stack) {
+    my $message = shift @stack;
+    my $data    = $message->{data};
+    my $type    = $message->{type};
+
+    if ($type eq '+' or $type eq '-' or $type eq ':') {
+      $str .= "$type$data\r\n";
+    }
+    elsif ($type eq '$') {
+      $str .= defined $data ? '$' . length($data) . "\r\n$data\r\n" : "\$-1\r\n";
+    }
+    elsif ($type eq '*') {
+      if (defined $data) {
+        $str .= '*' . scalar(@$data) . "\r\n";
+        unshift @stack, @$data;
+      }
+      else {
+        $str .= "*-1\r\n";
+      }
+    }
+    else {
+      confess "[Mojo::Redis::Protocol] Unknown message type $type";
+    }
+  }
+
+  return $self->{encoder} ? $self->{encoder}->encode($str, 0) : $str;
+}
+
+sub encoding {
+  my $self = shift;
+  return $self->{encoding} unless @_;
+  $self->{encoding} = shift // '';
+  $self->{encoder} = $self->{encoding} ? ($ENCODING{$self->{encoding}} ||= find_encoding($self->{encoding})) : undef;
+  Carp::confess("Unknown encoding '$self->{encoding}'") if $self->{encoding} and !$self->{encoder};
+  return $self;
+}
+
+sub new {
+  my $self = shift->SUPER::new(@_);
+  $self->encoding($self->{encoding});
+  $self->{buf} = '';
+  return $self;
+}
+
+sub parse {
+  my $self = shift;
+  my $curr = $self->{curr} ||= {level => 0};
+  my $buf  = \$self->{buf};
+  my $encoder;
+
+  $$buf .= shift;
+
+CHUNK:
+  while (length $$buf) {
+    do { local $_ = $$buf; s!\r\n!\\r\\n!g; warn "[Mojo::Redis::Protocol] parse($_)\n" } if DEBUG > 1;
+
+    # Look for initial type
+    if (!$curr->{type}) {
+      $curr->{type} = substr $$buf, 0, 1, '';
+      _parse_debug(start => $curr) if DEBUG > 1;
+    }
+
+    # Simple Strings, Errors, Integers
+    if ($curr->{type} eq '+' or $curr->{type} eq '-' or $curr->{type} eq ':') {
+      $curr->{len} //= index $$buf, "\r\n";
+      return $curr->{len} = undef if $curr->{len} < 0;    # Wait for more data
+
+      $curr->{data} = substr $$buf, 0, $curr->{len}, '';
+      substr $$buf, 0, 2, '';                             # Remove \r\n after data
+
+      # Force into correct data type
+      if ($curr->{type} eq ':') {
+        $curr->{data} += 0;
+      }
+      elsif ($encoder ||= $self->{encoder}) {
+        $curr->{data} = $encoder->decode($curr->{data}, 0);
+      }
+
+      _parse_debug(scalar => $curr) if DEBUG > 1;
+    }
+
+    # Bulk Strings
+    elsif ($curr->{type} eq '$') {
+      $curr->{stop} //= index $$buf, "\r\n";
+      return $curr->{stop} = undef if $curr->{stop} < 0;    # Wait for more data
+
+      $curr->{len} //= substr $$buf, 0, $curr->{stop}, '';
+      return undef if length($$buf) - 2 < $curr->{len};     # Wait for more data
+
+      $curr->{data} = $curr->{len} < 0 ? undef : substr $$buf, 2, $curr->{len}, '';
+      $curr->{data} = $encoder->decode($curr->{data}, 0) if $encoder ||= $self->{encoder};
+      substr $$buf, 0, 4, '';                               # Remove \r\n before and after data
+      _parse_debug(scalar => $curr) if DEBUG > 1;
+    }
+
+    # Arrays
+    elsif ($curr->{type} eq '*') {
+      $curr->{stop} //= index $$buf, "\r\n";
+      return $curr->{stop} = undef if $curr->{stop} < 0;    # Wait for more data
+
+      $curr->{size} //= substr $$buf, 0, $curr->{stop}, '';
+      return undef if length($$buf) - 2 < $curr->{size};    # Wait for more data
+
+      $curr->{data} = $curr->{size} < 0 ? undef : [];
+      substr $$buf, 0, 2, '';                               # Remove \r\n after array size
+      _parse_debug(array => $curr) if DEBUG > 1;
+
+      # Fill the array with data
+      if ($curr->{size} > 0) {
+        $curr = $self->{curr} = {level => $curr->{level} + 1, parent => $curr};
+        next CHUNK;
+      }
+    }
+
+    # Should not come to this
+    else {
+      confess "[Mojo::Redis::Protocol] Unknown message type $curr->{type}";
+    }
+
+    # Wait for more data
+    next CHUNK unless exists $curr->{data};
+
+    # Fill parent array with data
+    while (my $parent = delete $curr->{parent}) {
+      push @{$parent->{data}}, $curr->{data};
+      _parse_debug(parent => $parent) if DEBUG > 1;
+
+      if (@{$parent->{data}} < $parent->{size}) {
+        $curr = $self->{curr} = {level => $curr->{level}, parent => $parent};
+        next CHUNK;
+      }
+      else {
+        $curr = $self->{curr} = $parent;
+      }
+    }
+
+    unless ($curr->{level}) {
+      _parse_debug(emit => $self->{curr}) if DEBUG > 1;
+      $self->on_message->($self, $self->{curr});
+      $curr = $self->{curr} = {level => 0};
+    }
+  }
+
+  return 1;
+}
+
+sub _parse_debug {
+  my ($type, $item) = @_;
+  local $_ = join ', ', map {"$_=$item->{$_}"} sort grep { !/^(level)$/ } keys %$item;
+  s!\r\n!\\r\\n!g;
+  warn "[Mojo::Redis::Protocol] ($item->{level}) $type - $_\n";
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+Mojo::Redis::Protocol - Alternative to Protocol::Redis
+
+=head1 SYNOPSIS
+
+  use Mojo::Redis::Protocol;
+
+  my $protocol = Mojo::Redis::Protocol->new;
+
+  $protocol->encoding("UTF-8");
+
+  print $protocol->encode({...});
+
+  $protocol->on_message(sub { ... });
+  $protocol->parse($bytes);
+
+=head1 DESCRIPTION
+
+L<Mojo::Redis::Protocol> is a Redis protocol parser -
+L<https://redis.io/topics/protocol>.
+
+The API is currently higly EXPERIMENTAL and should probably not be used
+directly by other projects. The reason for this is that L</encode>
+and L</decode> is not symmetrical.
+
+=head1 ATTRIBUTES
+
+=head2 encoding
+
+  $protocol = $protocol->encoding("UTF-8");
+  $protocol = $protocol->encoding(undef); # same as pass-through
+  $encoding = $protocol->encoding;
+
+Used to set or read the encoding.
+
+=head1 METHODS
+
+=head2 encode
+
+  $bytes = $protocol->encode(\%data);
+
+Takes a message structure and turns it into bytes.
+
+=head2 new
+
+  $protocol = Mojo::Redis::Protocol->new;
+
+=head2 on_message
+
+  $protocol = $protocol->on_message(sub { ... });
+  $cb       = $protocol->on_message;
+
+A callback which will receive new messages parsed by L</parse>.
+
+=head2 parse
+
+  $protocol->parse($bytes);
+
+Used to parse bytest from the Redis server and call L</on_message> when a whole
+message is parsed.
+
+=head1 SEE ALSO
+
+L<Mojo::Redis>, L<Protocol::Redis> and L<Protocol::Redis::XS>.
+
+=cut

--- a/lib/Mojo/Redis/Protocol.pm
+++ b/lib/Mojo/Redis/Protocol.pm
@@ -16,8 +16,9 @@ sub encode {
   my $str = '';
   while (@stack) {
     my $message = shift @stack;
-    my $data    = $message->{data};
-    my $type    = $message->{type};
+    my $ref     = ref $message;
+    my $data    = $ref eq 'ARRAY' || !$ref ? $message : $message->{data};
+    my $type    = $ref eq 'ARRAY' ? '*' : !$ref ? '$' : $message->{type};
 
     if ($type eq '+' or $type eq '-' or $type eq ':') {
       $str .= "$type$data\r\n";

--- a/t/benchmark.t
+++ b/t/benchmark.t
@@ -3,10 +3,10 @@ use Test::More;
 use Benchmark qw(cmpthese timeit timestr :hireswallclock);
 
 plan skip_all => 'TEST_ONLINE=redis://localhost' unless $ENV{MOJO_REDIS_URL} = $ENV{TEST_ONLINE};
-plan skip_all => 'TEST_BENCHMARK=500' unless my $n_times = $ENV{TEST_BENCHMARK};
+plan skip_all => 'TEST_BENCHMARK=500'            unless my $n_times          = $ENV{TEST_BENCHMARK};
 
 my @classes   = qw(Mojo::Redis Mojo::Redis2);
-my @protocols = qw(Protocol::Redis Protocol::Redis::XS);
+my @protocols = qw(Mojo::Redis::Protocol Protocol::Redis Protocol::Redis::XS);
 my $key       = "test:benchmark:$0";
 my %t;
 
@@ -16,9 +16,7 @@ for my $class (@classes) {
   for my $protocol (@protocols) {
     eval "require $protocol;1" or next;
     my $redis = $class->new->protocol_class($protocol);
-    my $name = sprintf '%s/%s', $class =~ /::(\w+)$/, $protocol =~ /XS/ ? 'XS' : 'PP';
-
-    run($name, $redis->isa('Mojo::Redis2') ? $redis : $redis->db);
+    run($protocol, $redis->isa('Mojo::Redis2') ? $redis : $redis->db);
   }
 }
 

--- a/t/connection-sentinel.t
+++ b/t/connection-sentinel.t
@@ -4,26 +4,27 @@ use Mojo::Redis;
 
 my $port   = Mojo::IOLoop::Server->generate_port;
 my $conn_n = 0;
-my @messages;
+my @sent_to_server;
 
 Mojo::IOLoop->server(
   {port => $port},
   sub {
     my ($loop, $stream) = @_;
-    my $protocol = Protocol::Redis->new(api => 1);
-    my @res = ({type => '$', data => 'OK'});
+    my $protocol   = Mojo::Redis::Protocol->new;
+    my @reply_with = ({type => '$', data => 'OK'});
 
-    push @res,
+    push @reply_with,
       $conn_n == 0
       ? {type => '$', data => 'IDONTKNOW'}
       : {type => '*', data => [{type => '$', data => 'localhost'}, {type => '$', data => $port}]};
 
     my $cid = ++$conn_n;
     $protocol->on_message(sub {
-      push @messages, pop;
-      $messages[-1]{c} = $cid;
-      $stream->write($protocol->encode(shift @res)) if @res;
-      Mojo::IOLoop->stop if $messages[-1]{data}[0]{data} eq 'SELECT';
+      push @sent_to_server, pop;
+      die if @sent_to_server > 10;
+      $sent_to_server[-1]{c} = $cid;
+      $stream->write($protocol->encode(shift @reply_with)) if @reply_with;
+      Mojo::IOLoop->stop if $sent_to_server[-1]{data}[0] eq 'SELECT';
     });
 
     $stream->on(read => sub { $protocol->parse(pop) });
@@ -35,21 +36,16 @@ my $db    = $redis->db;
 $db->connection->_connect;
 Mojo::IOLoop->start;
 
-my @get_master_addr_by_name = (
-  {data => 'SENTINEL',                type => '$'},
-  {data => 'get-master-addr-by-name', type => '$'},
-  {data => 'mymaster',                type => '$'},
-);
-
+delete @$_{qw(level size stop)} for @sent_to_server;
 is_deeply(
-  \@messages,
+  \@sent_to_server,
   [
-    {c => 1, data => [{data => 'AUTH', type => '$'}, {data => 's3cret', type => '$'}], type => '*'},
-    {c => 1, data => \@get_master_addr_by_name,                                        type => '*'},
-    {c => 2, data => [{data => 'AUTH', type => '$'}, {data => 's3cret', type => '$'}], type => '*'},
-    {c => 2, data => \@get_master_addr_by_name,                                        type => '*'},
-    {c => 3, data => [{data => 'AUTH',   type => '$'}, {data => 's3cret', type => '$'}], type => '*'},
-    {c => 3, data => [{data => 'SELECT', type => '$'}, {data => '12',     type => '$'}], type => '*'},
+    {c => 1, data => [qw(AUTH s3cret)],                               type => '*'},
+    {c => 1, data => [qw(SENTINEL get-master-addr-by-name mymaster)], type => '*'},
+    {c => 2, data => [qw(AUTH s3cret)],                               type => '*'},
+    {c => 2, data => [qw(SENTINEL get-master-addr-by-name mymaster)], type => '*'},
+    {c => 3, data => [qw(AUTH s3cret)],                               type => '*'},
+    {c => 3, data => [qw(SELECT 12)],                                 type => '*'},
   ],
   'discovery + connect'
 );

--- a/t/redis.t
+++ b/t/redis.t
@@ -3,7 +3,7 @@ use Test::More;
 use Mojo::Redis;
 
 my $redis = Mojo::Redis->new;
-is $redis->protocol_class,  'Protocol::Redis',        'connection_class';
+is $redis->protocol_class,  'Mojo::Redis::Protocol',  'connection_class';
 is $redis->max_connections, 5,                        'max_connections';
 is $redis->url,             'redis://localhost:6379', 'default url';
 

--- a/t/xread.t
+++ b/t/xread.t
@@ -9,8 +9,6 @@ my $db          = $redis->db;
 my $stream_name = "test:stream:$0";
 my ($err, $len, $range, $read, $struct, @p);
 
-$redis->protocol_class($ENV{TEST_XS} ? 'Protocol::Redis::XS' : 'Protocol::Redis');
-
 note 'Fresh start';
 $db->del($stream_name);
 


### PR DESCRIPTION
I'm not quite sure how stable this protocol parser is, but it looks a lot faster 😄 

What do you think?

```
TEST_BENCHMARK=1000 TEST_ONLINE=redis://localhost prove -vl t/benchmark.t
t/benchmark.t ..
ok 1 - lrange Mojo::Redis::Protocol 2.55848 wallclock secs ( 2.39 usr +  0.05 sys =  2.44 CPU) @ 409.84/s (n=1000)
ok 2 - lrange Protocol::Redis 6.05703 wallclock secs ( 5.86 usr +  0.07 sys =  5.93 CPU) @ 168.63/s (n=1000)
ok 3 - lrange Protocol::Redis::XS 1.85635 wallclock secs ( 1.70 usr +  0.05 sys =  1.75 CPU) @ 571.43/s (n=1000)
# Cannot compare Redis/PP and Redis2/PP
                       Rate Protocol::Redis Mojo::Redis::Protocol Protocol::Redis::XS
Protocol::Redis       169/s              --                  -59%                -70%
Mojo::Redis::Protocol 410/s            143%                    --                -28%
Protocol::Redis::XS   571/s            239%                   39%                  --
1..3
ok
All tests successful.
Files=1, Tests=3, 11 wallclock secs ( 0.02 usr  0.01 sys + 10.23 cusr  0.19 csys = 10.45 CPU)
Result: PASS
```

----

Update 8. feb:

One of the big reasons why this is so much faster is that we don't have to loop over the data twice: https://github.com/jhthorsen/mojo-redis/blob/3901fef30999f7eabea5806d6fac7e86f4d9f489/lib/Mojo/Redis/Connection.pm#L178

`_on_message_cb()` is not in use at all when using Mojo::Redis::Protocol, which again saves at least one method call.

In addition, there's a lot less state and method calls inside the actual parser.

```
Protocol::Redis       167/s              --                  -60%                -71%
Mojo::Redis::Protocol 422/s            153%                    --                -26%
Protocol::Redis::XS   571/s            243%                   35%                  --
```