### PR TITLE
Only decode data from bulk string responses

### DIFF
--- a/lib/Mojo/Redis/Connection.pm
+++ b/lib/Mojo/Redis/Connection.pm
@@ -200,7 +200,8 @@ sub _parse_message_cb {
           return $err if defined $err;
           push @res, $res;
         }
-        elsif ($encoding and defined $m->{data}) {
+        # Only bulk string replies can contain binary-safe encoded data
+        elsif ($m->{type} eq '$' and $encoding and defined $m->{data}) {
           push @res, Mojo::Util::decode($encoding, $m->{data});
         }
         else {


### PR DESCRIPTION
As I discovered reviewing #38, only bulk string data can be encoded because the integer, simple string, and error types are not binary-safe (they cannot contain the bytes `\x0D` or `\x0A`). Also they will always be provided by the Redis server as ASCII strings. So when parsing we should only decode bulk string content, which may have been encoded when sent.