### PR TITLE
allow a custom URL object with userinfo in constructor

### DIFF
--- a/lib/Mojo/Redis.pm
+++ b/lib/Mojo/Redis.pm
@@ -7,6 +7,7 @@ use Mojo::Redis::Cache;
 use Mojo::Redis::Cursor;
 use Mojo::Redis::Database;
 use Mojo::Redis::PubSub;
+use Scalar::Util 'blessed';
 
 our $VERSION = '3.19';
 
@@ -35,8 +36,10 @@ sub db { Mojo::Redis::Database->new(redis => shift) }
 
 sub new {
   my $class = shift;
-  return $class->SUPER::new(url => Mojo::URL->new(shift), @_) if @_ % 2 and ref $_[0] ne 'HASH';
-  return $class->SUPER::new(@_);
+  return $class->SUPER::new(@_) unless @_ % 2 and ref $_[0] ne 'HASH';
+  my $url = shift;
+  $url = Mojo::URL->new($url) unless blessed $url and $url->isa('Mojo::URL');
+  return $class->SUPER::new(url => $url, @_);
 }
 
 sub _connection {

--- a/t/redis.t
+++ b/t/redis.t
@@ -1,6 +1,7 @@
 use Mojo::Base -strict;
 use Test::More;
 use Mojo::Redis;
+use Mojo::URL;
 
 my $redis = Mojo::Redis->new;
 is $redis->protocol_class,  'Protocol::Redis',        'connection_class';
@@ -11,8 +12,9 @@ $redis = Mojo::Redis->new('redis://redis.localhost', max_connections => 1);
 is $redis->url, 'redis://redis.localhost', 'custom url';
 is $redis->max_connections, 1, 'custom max_connections';
 
-$redis = Mojo::Redis->new(Mojo::URL->new('redis://redis.example.com'));
+$redis = Mojo::Redis->new(Mojo::URL->new('redis://redis.example.com')->userinfo('x:foo'));
 is $redis->url, 'redis://redis.example.com', 'custom url object';
+is $redis->url->userinfo, 'x:foo', 'userinfo retained';
 
 $redis = Mojo::Redis->new({max_connections => 3});
 is $redis->max_connections, 3, 'constructor with hash ref';


### PR DESCRIPTION
Currently if you pass a Mojo::URL object into the constructor it will be stringified into a new Mojo::URL object, losing any userinfo data. This allows a Mojo::URL object to be passed through unchanged.