### PR TITLE
Use Protocol::Redis::XS 0.06 or higher

### DIFF
--- a/t/redis.t
+++ b/t/redis.t
@@ -4,9 +4,9 @@ use Mojo::Redis;
 use Mojo::URL;
 
 my $redis = Mojo::Redis->new;
-is $redis->protocol_class,  'Protocol::Redis::Faster', 'connection_class';
-is $redis->max_connections, 5,                         'max_connections';
-is $redis->url,             'redis://localhost:6379',  'default url';
+like $redis->protocol_class, qr{^Protocol::Redis},     'connection_class';
+is $redis->max_connections,  5,                        'max_connections';
+is $redis->url,              'redis://localhost:6379', 'default url';
 
 $redis = Mojo::Redis->new('redis://redis.localhost', max_connections => 1);
 is $redis->url, 'redis://redis.localhost', 'custom url';


### PR DESCRIPTION
This is effectively a revert of https://github.com/jhthorsen/mojo-redis/commit/8c73f4b5bc75a8d03306c89890b9389e340775a0 to restore use of Protocol::Redis::XS if it's at least version 0.06, where the known issues have been resolved.