### PR TITLE
Correct circular reference in redis response parser

### DIFF
--- a/lib/Mojo/Redis/Connection.pm
+++ b/lib/Mojo/Redis/Connection.pm
@@ -214,6 +214,7 @@ sub _parse_message_cb {
     };
 
     my ($err, $res) = $unpack->(@messages);
+    undef $unpack;
     my $p = shift @{$self->{waiting} || []};
     return $p ? $p->reject($err) : $self->emit(error => $err) unless $res;
     return $p ? $p->resolve($res->[0]) : $self->emit(response => $res->[0]);


### PR DESCRIPTION
Fixes #52 as diagnosed by @TFBW

Three other options:

* Use current_sub feature instead of self-reference, bumping required Perl version to 5.16 (which recent Mojolicious versions require)
* Unroll the recursion in the same way Protocol::Redis was optimized, so the self reference is no longer needed
* Weaken trickery that I haven't figured out yet