### PR TITLE
Avoid circular reference in redis response parser

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,9 +9,18 @@ my %WriteMakefileArgs = (
   VERSION_FROM   => 'lib/Mojo/Redis.pm',
   EXE_FILES      => [qw()],
   OBJECT         => '',
-  BUILD_REQUIRES => {},
-  TEST_REQUIRES  => {'Test::More' => '0.88'},
-  PREREQ_PM      => {'Mojolicious' => '7.80', 'Protocol::Redis::Faster' => '0.002'},
+  BUILD_REQUIRES => {}
+,
+  TEST_REQUIRES  => {
+  'Test::More' => '0.88'
+}
+,
+  PREREQ_PM      => {
+  'Mojolicious' => '8.50',
+  'Protocol::Redis::Faster' => '0.002',
+  'perl' => '5.016'
+}
+,
   META_MERGE     => {
     'dynamic_config' => 0,
     'meta-spec'      => {version => 2},
@@ -24,7 +33,11 @@ my %WriteMakefileArgs = (
         web  => 'https://github.com/jhthorsen/mojo-redis',
       },
     },
-    'x_contributors' => ['Jan Henning Thorsen <jhthorsen@cpan.org>', 'Dan Book <grinnz@grinnz.com>'],
+    'x_contributors' => [
+  'Jan Henning Thorsen <jhthorsen@cpan.org>',
+  'Dan Book <grinnz@grinnz.com>'
+]
+,
   },
   test => {TESTS => (-e 'META.yml' ? 't/*.t' : 't/*.t xt/*.t')},
 );

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 # You can install this projct with curl -L http://cpanmin.us | perl - https://github.com/jhthorsen/mojo-redis/archive/master.tar.gz
-requires "Mojolicious"             => "7.80";
+requires "perl"                    => "5.016";
+requires "Mojolicious"             => "8.50";
 requires "Protocol::Redis::Faster" => "0.002";
 
 test_requires "Test::More" => "0.88";

--- a/lib/Mojo/Redis/Connection.pm
+++ b/lib/Mojo/Redis/Connection.pm
@@ -184,8 +184,7 @@ sub _parse_message_cb {
     my $encoding = $self->encoding;
     $self->_write;
 
-    my $unpack;
-    $unpack = sub {
+    my $unpack = sub {
       my @res;
 
       while (my $m = shift @_) {
@@ -196,7 +195,7 @@ sub _parse_message_cb {
           push @res, 0 + $m->{data};
         }
         elsif ($m->{type} eq '*' and ref $m->{data} eq 'ARRAY') {
-          my ($err, $res) = $unpack->(@{$m->{data}});
+          my ($err, $res) = __SUB__->(@{$m->{data}});
           return $err if defined $err;
           push @res, $res;
         }


### PR DESCRIPTION
Alternative to #59 to resolve #52.

Bump the requirement of perl to 5.16 and Mojolicious to 8.50 so that Mojo::Base will enable the current_sub feature.