### PR TITLE
Pubsub psubscribe fix

### DIFF
--- a/lib/Mojo/Redis/PubSub.pm
+++ b/lib/Mojo/Redis/PubSub.pm
@@ -105,8 +105,8 @@ sub _listen {
       return unless ref $res eq 'ARRAY' and @$res >= 3;
       my ($psub) = $res->[0] eq 'pmessage' ? splice @$res, 1, 1 : ();
       $res->[2] = eval { from_json $res->[2] } if $self->{json}{$res->[1]};
-      my $keyspace_listen = $self->{keyspace_listen}{$res->[1]};
-      for my $cb (@{$self->{chans}{$psub || $res->[1]}}) { $self->$cb($keyspace_listen ? [@$res[2, 3]] : $res->[2]) }
+      my $keyspace_listen = $self->{keyspace_listen}{$psub || $res->[1]};
+      for my $cb (@{$self->{chans}{$psub || $res->[1]}}) { $self->$cb($keyspace_listen ? [@$res[1, 2]] : $res->[2]) }
     }
   );
 

--- a/lib/Mojo/Redis/PubSub.pm
+++ b/lib/Mojo/Redis/PubSub.pm
@@ -103,9 +103,10 @@ sub _listen {
     response => sub {
       my ($conn, $res) = @_;    # $res = [$type, $name, $payload]
       return unless ref $res eq 'ARRAY' and @$res >= 3;
+      my ($psub) = $res->[0] eq 'pmessage' ? splice @$res, 1, 1 : ();
       $res->[2] = eval { from_json $res->[2] } if $self->{json}{$res->[1]};
       my $keyspace_listen = $self->{keyspace_listen}{$res->[1]};
-      for my $cb (@{$self->{chans}{$res->[1]}}) { $self->$cb($keyspace_listen ? [@$res[2, 3]] : $res->[2]) }
+      for my $cb (@{$self->{chans}{$psub || $res->[1]}}) { $self->$cb($keyspace_listen ? [@$res[2, 3]] : $res->[2]) }
     }
   );
 

--- a/t/pubsub.t
+++ b/t/pubsub.t
@@ -44,6 +44,20 @@ Mojo::IOLoop->timer(0.15 => sub { Mojo::IOLoop->stop });
 Mojo::IOLoop->start;
 is_deeply [sort @messages], ['message one', 'message two'], 'got messages' or diag join ", ", @messages;
 
+note 'test listen patterns';
+@messages = ();
+$pubsub->listen("rtest:$$:*" => \&gather);
+Mojo::IOLoop->timer(
+  0.2 => sub {
+    $pubsub->notify("rtest:$$:4" => 'message four');
+    $pubsub->notify("rtest:$$:5" => 'message five');
+  }
+);
+Mojo::IOLoop->start;
+
+is_deeply [sort @messages], ['message five', 'message four'], 'got messages' or diag join ", ", @messages;
+$pubsub->unlisten("rtest:$$:*");
+
 my $conn = $pubsub->connection;
 is @{$conn->subscribers('response')}, 1, 'only one message subscriber';
 


### PR DESCRIPTION
Quick fix (and test) to get psubscribe working.  Current code assumes a 'message' response from Redis but when a channel is psubscribed it returns a 'pmessage' response which has an additional element (original glob as well as the actual channel name)