### PR TITLE
Remove the ->multi_p(@promises) syntax

### DIFF
--- a/t/txn.t
+++ b/t/txn.t
@@ -27,8 +27,4 @@ is_deeply(\@res, ['QUEUED'], 'set after multi');
 undef $db;
 is $redis->db->get($key), 1012, 'rollback when $db goes out of scope';
 
-$db = $redis->db;
-$db->multi_p($db->set_p($key => 1011), $db->set_p($key), $db->get_p($key))->catch(sub { @res = @_ })->wait;
-like $res[0], qr{^ERR}, "invalid command: @res";
-
 done_testing;


### PR DESCRIPTION
See https://github.com/jhthorsen/mojo-redis/issues/68 for details.
The problem is that when calling multi_p(@promises), the promises
are already constructed when entering the multi_p subroutine, and their
commands could already be in flight to Redis, so they can be executed
outside the transaction, before the multi_p can issue the MULTI command
to Redis.