### PR TITLE
Fix connecting through sentinels

### DIFF
--- a/lib/Mojo/Redis/Connection.pm
+++ b/lib/Mojo/Redis/Connection.pm
@@ -120,7 +120,7 @@ sub _discover_master {
       $stream->on(read  => $self->_on_read_cb);
 
       $self->{stream} = $stream;
-      my $p = Mojo::Promise->new;
+      my $p = Mojo::Promise->new->ioloop($self->ioloop);
       unshift @{$self->{write}}, undef;    # prevent _write() from writing commands
       unshift @{$self->{write}}, [$self->_encode(SENTINEL => 'get-master-addr-by-name', $self->url->host), $p];
       unshift @{$self->{write}}, [$self->_encode(AUTH     => $url->password)] if length $url->password;


### PR DESCRIPTION
Fix for https://github.com/jhthorsen/mojo-redis/issues/76 :

When connecting to sentinels and sending get-master-addr-by-name query, the Mojo::Promise object should be bound to the Mojo::Redis' own ioloop, otherwise it is not fulfilled and the ->then() callback is not called.

Despite originally reported as authentication problem in #76, sentinel connection does not work at all, even when no authentication is set up. A minimal test case:

$ cat redis.conf
port 7000

$ cat sentinel.conf
port 7001
sentinel monitor mymaster 127.0.0.1 7000 1
sentinel down-after-milliseconds mymaster 60000

$ redis-server ./redis.conf &
$ redis-sentinel ./sentinel.conf &
$ perl -MRedis -E 'my $r = Redis->new(service=>"mymaster", sentinels=>["127.0.0.1:7001"]); $r->set("/test" => 42, EX => 100); say $r->get("/test")'
42
$ MOJO_REDIS_DEBUG=1 perl -MMojo::Redis -E 'my $r = Mojo::Redis->new("redis://mymaster?sentinel=127.0.0.1:7001"); $r->db->set("/test" => 42); say $r->db->get("/test");'