### PR TITLE
Add TLS attributes to Mojo::Redis and Mojo::Redis::Connection

### DIFF
--- a/lib/Mojo/Redis.pm
+++ b/lib/Mojo/Redis.pm
@@ -49,11 +49,21 @@ sub _connection {
   my ($self, %args) = @_;
 
   $args{ioloop} ||= Mojo::IOLoop->singleton;
+  my %tls_args;
+  if (my %url_args = %{$self->url->query->to_hash}) {
+    @tls_args{qw/ tls tls_ca tls_cert tls_key /} = @url_args{qw/ tls ca cert key /};
+    delete @tls_args{grep !defined $tls_args{$_}, keys %tls_args};
+    my %tls_options = map { ($_, $url_args{$_}) } grep /^SSL_/, keys %url_args;
+    $tls_options{$_} = [split /,/, $tls_options{$_}]
+      foreach grep /^SSL_(psk|(npn|alpn)_protocols)\z/, keys %tls_options;
+    $tls_args{tls_options} = \%tls_options if %tls_options;
+    $tls_args{tls} //= 1                   if %tls_args;
+  }
   my $conn = Mojo::Redis::Connection->new(
     encoding => $self->encoding,
     protocol => $self->protocol_class->new(api => 1),
     url      => $self->url->clone,
-    %args
+    %args, %tls_args
   );
 
   Scalar::Util::weaken($self);
@@ -235,6 +245,10 @@ L<Mojo::Redis::Cursor/new>. for possible commands.
   $redis = Mojo::Redis->new(Mojo::URL->new->host("/tmp/redis.sock"));
   $redis = Mojo::Redis->new(\%attrs);
   $redis = Mojo::Redis->new(%attrs);
+
+  # TLS options
+  $redis = Mojo::Redis->new("redis://localhost:6379/1?tls=1");
+  $redis = Mojo::Redis->new("redis://localhost:6379/1?ca=ca.pem&cert=cert.pem&key=key.pem&SSL_alpn_protocols=foo");
 
 Object constructor. Can coerce a string into a L<Mojo::URL> and set L</url>
 if present.

--- a/lib/Mojo/Redis/Connection.pm
+++ b/lib/Mojo/Redis/Connection.pm
@@ -13,6 +13,7 @@ has encoding => sub { Carp::confess('encoding is required in constructor') };
 has ioloop   => sub { Carp::confess('ioloop is required in constructor') };
 has protocol => sub { Carp::confess('protocol is required in constructor') };
 has url      => sub { Carp::confess('url is required in constructor') };
+has [qw/ tls tls_ca tls_cert tls_key tls_options /];
 
 sub DESTROY {
   my $self = shift;
@@ -58,7 +59,14 @@ sub _connect {
   delete $self->{master_url};     # Make sure we forget master_url so we can reconnect
   $self->protocol->on_message($self->_parse_message_cb);
   $self->{id} = $self->ioloop->client(
-    $self->_connect_args($url, {port => 6379, timeout => CONNECT_TIMEOUT}),
+    $self->_connect_args(
+      $url,
+      {
+        port    => 6379,
+        timeout => CONNECT_TIMEOUT,
+        map { ($_ => $self->$_) } grep defined $self->{$_}, qw/ tls tls_ca tls_cert tls_key tls_options /
+      }
+    ),
     sub {
       return unless $self;
       my ($loop, $err, $stream) = @_;
@@ -95,6 +103,8 @@ sub _connect_args {
   }
 
   $args{timeout} = $defaults->{timeout} || CONNECT_TIMEOUT;
+
+  $args{$_} = $defaults->{$_} foreach grep /^tls/, keys %$defaults;
   return \%args;
 }
 
@@ -329,6 +339,41 @@ Holds an instance of L<Mojo::IOLoop>.
 
 Holds a protocol object, such as L<Protocol::Redis::Faster> that is used to
 generate and parse Redis messages.
+
+=head2 tls
+
+  my $tls = $conn->tls;
+  $conn   = $conn->tls(1);
+
+See L<Mojo::IOLoop::Client/tls>
+
+=head2 tls_ca
+
+  my $tls_ca = $conn->tls_ca;
+  $conn      = $conn->tls_ca('/etc/tls/ca.crt');
+
+See L<Mojo::IOLoop::Client/tls_ca>
+
+=head2 tls_cert
+
+  my $tls_cert = $conn->tls_cert;
+  $conn        = $conn->tls_cert('/etc/tls/client.crt');
+
+See L<Mojo::IOLoop::Client/tls_cert>
+
+=head2 tls_key
+
+  my $tls_key = $conn->tls_key;
+  $conn       = $conn->tls_key('/etc/tls/client.key');
+
+See L<Mojo::IOLoop::Client/tls_key>
+
+=head2 tls_options
+
+  my $tls_options = $conn->tls_options;
+  $conn           = $conn->tls_options({SSL_alpn_protocols => ['foo', 'bar'], SSL_verify_mode => 0x00});
+
+See L<Mojo::IOLoop::Client/tls_options>
 
 =head2 url
 

--- a/t/connection.t
+++ b/t/connection.t
@@ -130,4 +130,45 @@ isnt $db->connection(1)->ioloop, Mojo::IOLoop->singleton, 'blocking connection';
 isnt $db->connection(1)->ioloop, $db->connection(0)->ioloop,
   'blocking connection does not share non-blocking connection ioloop';
 
+note 'Without TLS options';
+$db = $redis->db;
+$conn = $db->connection;
+is $conn->tls, undef, 'tls disabled';
+is $conn->tls_ca, undef, 'no custom tls ca certificate';
+is $conn->tls_cert, undef, 'no custom client tls certificate';
+is $conn->tls_key, undef, 'no custom client tls key';
+is $conn->tls_options, undef, 'no custom tls options';
+
+note 'TLS options passed on to connection';
+$redis = Mojo::Redis->new(
+    'redis://redis.localhost?ca=/var/mojo/app/ca.crt&cert=/var/mojo/app/client.crt&key=/var/mojo/app/client.key&SSL_alpn_protocols=foo',
+);
+$db = $redis->db;
+$conn = $db->connection;
+is $conn->tls, 1, 'tls enabled';
+is $conn->tls_ca, '/var/mojo/app/ca.crt', 'custom tls ca certificate';
+is $conn->tls_cert, '/var/mojo/app/client.crt', 'custom client tls certificate';
+is $conn->tls_key, '/var/mojo/app/client.key', 'custom client tls key';
+is $conn->tls_options->{SSL_alpn_protocols}[0], 'foo', 'custom tls options';
+
+note 'TLS Options passed on to Mojo::IOLoop::Client';
+my $original_ioloop_client_connect_ref = \&Mojo::IOLoop::Client::connect;
+my $ioloop_client_connect_args;
+Mojo::Util::monkey_patch('Mojo::IOLoop::Client', 'connect' => sub { $ioloop_client_connect_args = $_[1] });
+
+$conn->_connect;
+is_deeply $ioloop_client_connect_args, {
+    address     => 'redis.localhost',
+    port        => 6379,
+    timeout     => 10,
+    tls         => 1,
+    tls_ca      => '/var/mojo/app/ca.crt',
+    tls_cert    => '/var/mojo/app/client.crt',
+    tls_key     => '/var/mojo/app/client.key',
+    tls_options => {
+        SSL_alpn_protocols => ['foo']
+    }
+}, 'connect args';
+Mojo::Util::monkey_patch('Mojo::IOLoop::Client', 'connect' => $original_ioloop_client_connect_ref);
+
 done_testing;


### PR DESCRIPTION
This patch would allow TLS connections to be initiated.

```perl
my $redis = Mojo::Redis->new($redis_url, tls => 1, tls_ca => ...);
```

Includes documentation and tried it on my own server with the `tls => 1` option (it worked).

**EDIT**: TLS params are not passed that way anymore, but as URL parameters, in the way that the module author requested them to be, in another PR.